### PR TITLE
Installation fails with conflicting dependencies error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,16 @@ in this case.
 
 From GitHub:
 
-    git clone https://github.com/BioComputingUP/MobiDB-lite.git
-    pip install .
+```bash
+git clone https://github.com/BioComputingUP/MobiDB-lite.git
+
+# one-off
+python3 -m venv .venv
+
+source .venv/bin/activate
+    
+pip install .
+```
 
 ### How to install MobiDB-lite using Conda?
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ MobiDB-lite is also available as Docker container [MobiDB-lite_docker](https://g
 
 
 ## Installation
+
+Supported Python versions: >=3.11,<3.15
+
 You can use the tool simply cloning this repo and running `__main__.py` Python script. 
 which implements a command line interface.
 To avoid import errors you need to add the source root folder 
@@ -41,10 +44,15 @@ From GitHub:
     git clone https://github.com/BioComputingUP/MobiDB-lite.git
     pip install .
 
-To install the dependencies:  
+### How to install MobiDB-lite using Conda?
 
-    pip install -r requirements.txt
+You can create a Conda environment and install MobiDB-lite using the following commands:
 
+```bash
+conda create -n mobidb_lite python=3.12
+conda activate mobidb_lite
+pip install .
+```
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,15 @@ authors = [
   {name = "Damiano Piovesan", email = "damiano.piovesan@unipd.it"},
   {name = "Mahta Mehdiabadi", email = "mahta.mehdiabadi@studenti.unipd.it"}
 ]
-requires-python = ">=3.12.3"
-dependencies = []
+requires-python = ">=3.11.3,<3.15"
+dependencies = [
+  "joblib >= 1.5.2",
+  "numba >= 0.61.2",
+  "pandas >= 2.3.2",
+  "scikit-learn >= 1.4.2",
+]
 
 [project.optional-dependencies]
-nu = [
-  "scikit-learn >= 1.4.2",
-  "numba >= 0.59.1"
-]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 joblib==1.5.2
 numba==0.61.2
-numpy==2.3.2
 pandas==2.3.2
 scikit-learn==1.4.2
-setuptools==59.6.0


### PR DESCRIPTION
### How to reproduce?

Install Python version 3.12 and source the environment.

When running:
`pip install .`
within the checkout clone directory, we get the following error:

### Error thrown:
When installing MobiDB-lite locally we get the following error:

ERROR: Cannot install -r requirements.txt (line 2) and numpy==2.3.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==2.3.2
    numba 0.61.2 depends on numpy<2.3 and >=1.24

Additionally, some packages in these conflicts have no matching distributions available for your environment:
    numpy

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts

### Suggested fix
We applied a few fixes to the installation configuration, e.g. made optional dependencies mandatory, specified supported Python versions within toml file and also moved all required dependencies to the toml file.